### PR TITLE
feat(filepath): Use the path/filepath package

### DIFF
--- a/internal/download.go
+++ b/internal/download.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"net/http"
 	"os"
-	"path"
+	"path/filepath"
 	"sync"
 )
 
@@ -56,8 +56,8 @@ func download(link, output string) error {
 	}
 	defer resp.Body.Close()
 
-	_, fileName := path.Split(link)
-	file, err := os.Create(path.Join(output, fileName))
+	_, fileName := filepath.Split(link)
+	file, err := os.Create(filepath.Join(output, fileName))
 	if err != nil {
 		return err
 	}

--- a/output.go
+++ b/output.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"path"
+	"path/filepath"
 
 	"github.com/yyoshiki41/radigo/internal"
 )
@@ -18,7 +18,7 @@ func initTempAACDir() (string, error) {
 		return "", err
 	}
 
-	aacResultFile = path.Join(aacDir, "result.aac")
+	aacResultFile = filepath.Join(aacDir, "result.aac")
 	return aacDir, nil
 }
 

--- a/rec.go
+++ b/rec.go
@@ -5,7 +5,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
-	"path"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -125,7 +125,7 @@ func (c *recCommand) Run(args []string) int {
 		return 1
 	}
 
-	outputFile := path.Join(radigoPath, "output",
+	outputFile := filepath.Join(radigoPath, "output",
 		fmt.Sprintf("%s-%s.%s",
 			startTime.In(location).Format(datetimeLayout), stationID, fileType,
 		))

--- a/rec_live.go
+++ b/rec_live.go
@@ -5,7 +5,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
-	"path"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -99,7 +99,7 @@ func (c *recLiveCommand) Run(args []string) int {
 	tempDir, removeTempDir := internal.CreateTempDir()
 	defer removeTempDir()
 
-	swfPlayer := path.Join(tempDir, "myplayer.swf")
+	swfPlayer := filepath.Join(tempDir, "myplayer.swf")
 	if err := radiko.DownloadPlayer(swfPlayer); err != nil {
 		c.ui.Error(fmt.Sprintf(
 			"Failed to download swf player. %s", err))
@@ -135,12 +135,12 @@ func (c *recLiveCommand) Run(args []string) int {
 
 	var outputFile string
 	if outputFilename == "" {
-		outputFile = path.Join(radigoPath, "output",
+		outputFile = filepath.Join(radigoPath, "output",
 			fmt.Sprintf("%s-%s.mp3",
 				time.Now().In(location).Format(datetimeLayout), stationID,
 			))
 	} else {
-		outputFile = path.Join(radigoPath, "output",
+		outputFile = filepath.Join(radigoPath, "output",
 			fmt.Sprintf("%s", outputFilename))
 	}
 


### PR DESCRIPTION
```
The path package should only be used for paths separated by forward slashes, such as the paths in URLs.
This package does not deal with Windows paths with drive letters or backslashes;
to manipulate operating system paths, use the path/filepath package.
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/yyoshiki41/radigo/19)
<!-- Reviewable:end -->
