### PR TITLE
Reduce the intermediate file size during concatenation

### DIFF
--- a/ffmpeg.go
+++ b/ffmpeg.go
@@ -152,5 +152,10 @@ func ConcatAACFiles(ctx context.Context, input []string, resourcesDir string, ou
 	f.setInput(listFile.Name())
 	f.setArgs("-c", "copy")
 	// TODO: Collect log
-	return f.run(output)
+	err = f.run(output)
+	// Remove the intermediate files right after they are concatenated into one file
+	for _, f := range input {
+		defer os.Remove(f)
+	}
+	return err
 }


### PR DESCRIPTION
* Remove the intermediate files right after they are concatenated into
  one file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/yyoshiki41/radigo/56)
<!-- Reviewable:end -->
