### PR TITLE
Browse-Live: Remove unusable option description

### DIFF
--- a/browse_live.go
+++ b/browse_live.go
@@ -49,6 +49,5 @@ Usage: radigo browse-live [options]
   Browse radiko.jp live
 Options:
   -id=name                 Station id
-  -time,t=3600             Time duration (sec)
 `)
 }


### PR DESCRIPTION
The description of the `browse-live` command says it has two options: `station id` and `time`.
However, the `browse-live` command does not support the time option. So, I removed it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/yyoshiki41/radigo/66)
<!-- Reviewable:end -->
