### PR TITLE
rec-live: fix record forever

### DIFF
--- a/rec_live.go
+++ b/rec_live.go
@@ -127,6 +127,7 @@ func (c *recLiveCommand) Run(args []string) int {
 		"-loglevel", "quiet",
 		"-fflags", "+discardcorrupt",
 		"-headers", "X-Radiko-Authtoken: " + client.AuthToken(),
+		"-t", duration,
 		"-i", streamURL,
 		"-vn",
 		"-acodec",


### PR DESCRIPTION
fix: #68 

When the rec-live option is specified, a duration must be specified with the -t parameter. However, this parameter is ignored and recording continues forever.

Set the recording time by specifying the -t option when executing the ffmpeg command.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/yyoshiki41/radigo/69)
<!-- Reviewable:end -->
