### PR TITLE
Fix seekable

### DIFF
--- a/browse.go
+++ b/browse.go
@@ -3,7 +3,6 @@ package radigo
 import (
 	"flag"
 	"fmt"
-	"os/exec"
 	"strings"
 	"time"
 
@@ -39,8 +38,7 @@ func (c *browseCommand) Run(args []string) int {
 	}
 
 	url := radiko.GetTimeshiftURL(stationID, startTime)
-	cmd := exec.Command("open", url)
-	if err := cmd.Run(); err != nil {
+	if err := openBrowser(url); err != nil {
 		c.ui.Error(fmt.Sprintf(
 			"Failed to open browser: %s", err))
 	}

--- a/browse_live.go
+++ b/browse_live.go
@@ -26,7 +26,7 @@ func openBrowser(url string) error {
 	case "darwin":
 		err = exec.Command("open", url).Start()
 	default:
-		err = fmt.Errorf("unsupported platform")
+		err = fmt.Errorf("unsupported platform: %s", runtime.GOOS)
 	}
 	return err
 }

--- a/browse_live.go
+++ b/browse_live.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"fmt"
 	"os/exec"
+	"runtime"
 	"strings"
 
 	"github.com/mitchellh/cli"
@@ -12,6 +13,22 @@ import (
 
 type browseLiveCommand struct {
 	ui cli.Ui
+}
+
+func openBrowser(url string) error {
+	var err error
+
+	switch runtime.GOOS {
+	case "linux":
+		err = exec.Command("xdg-open", url).Start()
+	case "windows":
+		err = exec.Command("rundll32", "url.dll,FileProtocolHandler", url).Start()
+	case "darwin":
+		err = exec.Command("open", url).Start()
+	default:
+		err = fmt.Errorf("unsupported platform")
+	}
+	return err
 }
 
 func (c *browseLiveCommand) Run(args []string) int {
@@ -30,8 +47,7 @@ func (c *browseLiveCommand) Run(args []string) int {
 	}
 
 	url := radiko.GetLiveURL(stationID)
-	cmd := exec.Command("open", url)
-	if err := cmd.Run(); err != nil {
+	if err := openBrowser(url); err != nil {
 		c.ui.Error(fmt.Sprintf(
 			"Failed to open browser: %s", err))
 	}

--- a/rec_live.go
+++ b/rec_live.go
@@ -126,7 +126,8 @@ func (c *recLiveCommand) Run(args []string) int {
 	ffmpegArgs := []string{
 		"-loglevel", "quiet",
 		"-fflags", "+discardcorrupt",
-		"-headers", "X-Radiko-Authtoken: " + client.AuthToken(),
+		"-http_seekable", "0",
+		"-headers", "X-Radiko-AuthToken: " + client.AuthToken(),
 		"-t", duration,
 		"-i", streamURL,
 		"-vn",


### PR DESCRIPTION
points 
* fix auth token header `s/Authtoken/AuthToken/`
* -http_seekable must be disabled since ffmpeg parser does not handle rediko correctly
* do not use "open" command since Windows does not have it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/yyoshiki41/radigo/81)
<!-- Reviewable:end -->
