### PR TITLE
Refactor: Replace io/ioutil.TempDir with os.MkdirTemp

### DIFF
--- a/internal/util.go
+++ b/internal/util.go
@@ -1,13 +1,12 @@
 package internal
 
 import (
-	"io/ioutil"
 	"log"
 	"os"
 )
 
 func CreateTempDir() (string, func()) {
-	dir, err := ioutil.TempDir("", "radigo")
+	dir, err := os.MkdirTemp("", "radigo")
 	if err != nil {
 		log.Fatalf("Failed to create temp dir: %s", err)
 	}


### PR DESCRIPTION
I replaced the deprecated `io/ioutil.TempDir` function with the recommended `os.MkdirTemp` equivalent in `internal/util.go`.

This change maintains the same functionality for creating temporary directories.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/yyoshiki41/radigo/82)
<!-- Reviewable:end -->
