### PR TITLE
Fix timeshift recording by using new radiko playlist endpoint

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.19
 
 require (
 	github.com/briandowns/spinner v1.19.0
+	github.com/grafov/m3u8 v0.11.1
 	github.com/mitchellh/cli v1.1.4
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/yyoshiki41/go-radiko v0.9.0
@@ -17,7 +18,6 @@ require (
 	github.com/bgentry/speakeasy v0.1.0 // indirect
 	github.com/fatih/color v1.7.0 // indirect
 	github.com/google/uuid v1.1.2 // indirect
-	github.com/grafov/m3u8 v0.11.1 // indirect
 	github.com/hashicorp/errwrap v1.0.0 // indirect
 	github.com/hashicorp/go-multierror v1.0.0 // indirect
 	github.com/huandu/xstrings v1.3.2 // indirect

--- a/internal/download.go
+++ b/internal/download.go
@@ -18,6 +18,10 @@ const (
 var sem = make(chan struct{}, maxConcurrents)
 
 func BulkDownload(list []string, output string) error {
+	return BulkDownloadWithHeader(list, output, nil)
+}
+
+func BulkDownloadWithHeader(list []string, output string, header http.Header) error {
 	var errFlag bool
 	var wg sync.WaitGroup
 
@@ -29,7 +33,7 @@ func BulkDownload(list []string, output string) error {
 			var err error
 			for i := 0; i < maxAttempts; i++ {
 				sem <- struct{}{}
-				err = download(link, output)
+				err = download(link, output, header)
 				<-sem
 				if err == nil {
 					break
@@ -49,8 +53,18 @@ func BulkDownload(list []string, output string) error {
 	return nil
 }
 
-func download(link, output string) error {
-	resp, err := http.Get(link)
+func download(link, output string, header http.Header) error {
+	req, err := http.NewRequest("GET", link, nil)
+	if err != nil {
+		return err
+	}
+	for k, vs := range header {
+		for _, v := range vs {
+			req.Header.Add(k, v)
+		}
+	}
+
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return err
 	}

--- a/rec.go
+++ b/rec.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"net/http"
 	"os"
 	"strings"
 	"time"
@@ -11,7 +12,6 @@ import (
 	"github.com/briandowns/spinner"
 	"github.com/mitchellh/cli"
 	"github.com/olekukonko/tablewriter"
-	"github.com/yyoshiki41/go-radiko"
 	"github.com/yyoshiki41/radigo/internal"
 )
 
@@ -92,29 +92,23 @@ func (c *recCommand) Run(args []string) int {
 		return 1
 	}
 
-	go func() {
-		pg, err := client.GetProgramByStartTime(ctx, stationID, startTime)
-		if err != nil {
-			ctxCancel()
-			c.ui.Error(fmt.Sprintf(
-				"Failed to get the program: %s", err))
-		}
-
-		table := tablewriter.NewWriter(os.Stdout)
-		table.SetHeader([]string{"STATION ID", "TITLE"})
-		table.Append([]string{stationID, pg.Title})
-		fmt.Print("\n")
-		table.Render()
-	}()
-
-	uri, err := client.TimeshiftPlaylistM3U8(ctx, stationID, startTime)
+	prog, err := client.GetProgramByStartTime(ctx, stationID, startTime)
 	if err != nil {
 		c.ui.Error(fmt.Sprintf(
-			"Failed to get playlist.m3u8: %s", err))
+			"Failed to get the program: %s", err))
 		return 1
 	}
 
-	chunklist, err := radiko.GetChunklistFromM3U8(uri)
+	table := tablewriter.NewWriter(os.Stdout)
+	table.SetHeader([]string{"STATION ID", "TITLE"})
+	table.Append([]string{stationID, prog.Title})
+	fmt.Print("\n")
+	table.Render()
+
+	authToken := client.AuthToken()
+	areafree := areaID != "" && areaID != currentAreaID
+
+	chunklist, err := getTimeshiftChunklist(stationID, prog.Ft, prog.To, authToken, areafree)
 	if err != nil {
 		c.ui.Error(fmt.Sprintf(
 			"Failed to get chunklist: %s", err))
@@ -129,7 +123,9 @@ func (c *recCommand) Run(args []string) int {
 	}
 	defer os.RemoveAll(aacDir) // clean up
 
-	if err := internal.BulkDownload(chunklist, aacDir); err != nil {
+	aacHeader := make(http.Header)
+	aacHeader.Set("X-Radiko-AuthToken", authToken)
+	if err := internal.BulkDownloadWithHeader(chunklist, aacDir, aacHeader); err != nil {
 		c.ui.Error(fmt.Sprintf(
 			"Failed to download aac files: %s", err))
 		return 1

--- a/timeshift.go
+++ b/timeshift.go
@@ -1,0 +1,232 @@
+package radigo
+
+import (
+	"crypto/md5"
+	"encoding/xml"
+	"fmt"
+	"math/rand"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/grafov/m3u8"
+)
+
+const chunkSeconds = 300
+
+type streamURLs struct {
+	URLs []streamURL `xml:"url"`
+}
+
+type streamURL struct {
+	Areafree          int    `xml:"areafree,attr"`
+	Timefree          int    `xml:"timefree,attr"`
+	PlaylistCreateURL string `xml:"playlist_create_url"`
+}
+
+func generateLsid() string {
+	b := make([]byte, 16)
+	for i := range b {
+		b[i] = byte(rand.Intn(256))
+	}
+	return fmt.Sprintf("%x", md5.Sum(b))
+}
+
+func getTimefreeStreamURL(stationID string, areafree bool) (string, error) {
+	apiURL := fmt.Sprintf("https://radiko.jp/v3/station/stream/pc_html5/%s.xml", stationID)
+	resp, err := http.Get(apiURL)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("failed to get stream XML: status %d", resp.StatusCode)
+	}
+
+	var urls streamURLs
+	if err := xml.NewDecoder(resp.Body).Decode(&urls); err != nil {
+		return "", fmt.Errorf("failed to decode stream XML: %w", err)
+	}
+
+	wantAreafree := 0
+	if areafree {
+		wantAreafree = 1
+	}
+
+	for _, u := range urls.URLs {
+		if u.Timefree == 1 && u.Areafree == wantAreafree {
+			return u.PlaylistCreateURL, nil
+		}
+	}
+	for _, u := range urls.URLs {
+		if u.Timefree == 1 {
+			return u.PlaylistCreateURL, nil
+		}
+	}
+	return "", fmt.Errorf("no timefree stream URL found for station %s", stationID)
+}
+
+func isAbsoluteURL(s string) bool {
+	u, err := url.Parse(s)
+	return err == nil && u.Scheme != ""
+}
+
+func resolveReference(baseURL, ref string) (string, error) {
+	base, err := url.Parse(baseURL)
+	if err != nil {
+		return "", err
+	}
+	r, err := url.Parse(ref)
+	if err != nil {
+		return "", err
+	}
+	return base.ResolveReference(r).String(), nil
+}
+
+// fetchMedialistURL fetches the master playlist and returns the medialist URI.
+func fetchMedialistURL(playlistBaseURL, stationID, startAt, ft, to, authToken string, l int) (string, error) {
+	u, err := url.Parse(playlistBaseURL)
+	if err != nil {
+		return "", err
+	}
+	q := u.Query()
+	q.Set("station_id", stationID)
+	q.Set("start_at", startAt)
+	q.Set("ft", ft)
+	q.Set("end_at", to)
+	q.Set("to", to)
+	q.Set("l", fmt.Sprintf("%d", l))
+	q.Set("lsid", generateLsid())
+	q.Set("type", "b")
+	u.RawQuery = q.Encode()
+
+	req, err := http.NewRequest("GET", u.String(), nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("X-Radiko-AuthToken", authToken)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("failed to get timeshift playlist: status %d", resp.StatusCode)
+	}
+
+	baseForResolve := resp.Request.URL.String()
+
+	playlist, listType, err := m3u8.DecodeFrom(resp.Body, true)
+	if err != nil {
+		return "", fmt.Errorf("failed to decode m3u8: %w", err)
+	}
+	if listType != m3u8.MASTER {
+		return "", fmt.Errorf("unexpected playlist type: %d", listType)
+	}
+	p := playlist.(*m3u8.MasterPlaylist)
+	if p == nil || len(p.Variants) == 0 || p.Variants[0] == nil {
+		return "", fmt.Errorf("invalid m3u8 format: no variants")
+	}
+
+	variantURI := p.Variants[0].URI
+	if !isAbsoluteURL(variantURI) {
+		variantURI, err = resolveReference(baseForResolve, variantURI)
+		if err != nil {
+			return "", fmt.Errorf("failed to resolve variant URI: %w", err)
+		}
+	}
+	return variantURI, nil
+}
+
+// fetchChunklist fetches a medialist and returns segment URLs.
+func fetchChunklist(uri, authToken string) ([]string, error) {
+	req, err := http.NewRequest("GET", uri, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("X-Radiko-AuthToken", authToken)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("failed to get chunklist: status %d", resp.StatusCode)
+	}
+
+	baseForResolve := resp.Request.URL.String()
+
+	playlist, listType, err := m3u8.DecodeFrom(resp.Body, true)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode m3u8: %w", err)
+	}
+	if listType != m3u8.MEDIA {
+		return nil, fmt.Errorf("unexpected playlist type: %d", listType)
+	}
+	p := playlist.(*m3u8.MediaPlaylist)
+
+	var chunklist []string
+	for _, v := range p.Segments {
+		if v != nil {
+			chunkURI := v.URI
+			if !isAbsoluteURL(chunkURI) {
+				chunkURI, err = resolveReference(baseForResolve, chunkURI)
+				if err != nil {
+					return nil, fmt.Errorf("failed to resolve chunk URI: %w", err)
+				}
+			}
+			chunklist = append(chunklist, chunkURI)
+		}
+	}
+	return chunklist, nil
+}
+
+// getTimeshiftChunklist fetches all segment URLs for a timefree program
+// by splitting the program into chunks (the API limits each request).
+func getTimeshiftChunklist(stationID, ft, to, authToken string, areafree bool) ([]string, error) {
+	playlistBaseURL, err := getTimefreeStreamURL(stationID, areafree)
+	if err != nil {
+		return nil, err
+	}
+
+	loc, err := time.LoadLocation(tz)
+	if err != nil {
+		return nil, err
+	}
+	ftTime, err := time.ParseInLocation(datetimeLayout, ft, loc)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse ft: %w", err)
+	}
+	toTime, err := time.ParseInLocation(datetimeLayout, to, loc)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse to: %w", err)
+	}
+	totalDuration := int(toTime.Sub(ftTime).Seconds())
+
+	var allChunks []string
+	for offset := 0; offset < totalDuration; offset += chunkSeconds {
+		chunkStart := ftTime.Add(time.Duration(offset) * time.Second)
+		l := chunkSeconds
+		if offset+l > totalDuration {
+			l = totalDuration - offset
+		}
+
+		startAt := chunkStart.Format(datetimeLayout)
+		mediaURL, err := fetchMedialistURL(playlistBaseURL, stationID, startAt, ft, to, authToken, l)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get medialist (offset=%d): %w", offset, err)
+		}
+
+		chunks, err := fetchChunklist(mediaURL, authToken)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get chunklist (offset=%d): %w", offset, err)
+		}
+		allChunks = append(allChunks, chunks...)
+	}
+	return allChunks, nil
+}


### PR DESCRIPTION
radiko changed their timefree playlist API. The old endpoint POST radiko.jp/v2/api/ts/playlist.m3u8 no longer works.

Key changes:
- Get the correct timefree playlist URL dynamically from the station stream XML (/v3/station/stream/pc_html5/{station_id}.xml) instead of using a hardcoded endpoint
- Split program into 300-second chunks since the API limits the number of segments per request (controlled by the 'l' parameter)
- Pass X-Radiko-AuthToken header through all M3U8 and chunk requests
- Add BulkDownloadWithHeader for auth-aware parallel chunk downloads

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/yyoshiki41/radigo/87)
<!-- Reviewable:end -->
